### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     }


### PR DESCRIPTION
Fix type import issues

previously when importing this package using the latest version of TypeScript, TypeScript would complain that the "types" key was missing from the package.json and would fail to resolve the proper types